### PR TITLE
Add events

### DIFF
--- a/klh_core/src/config.rs
+++ b/klh_core/src/config.rs
@@ -5,6 +5,7 @@ pub enum CorePlugins {
   Buffers,
   Diagnostics,
   Displays,
+  TestClient,
 }
 
 /// An object containing a representation of any configuration needed
@@ -19,7 +20,8 @@ impl Default for KlhConfig {
       core_plugins: vec!(
 	CorePlugins::Buffers,
 	CorePlugins::Diagnostics,
-	CorePlugins::Displays
+	CorePlugins::Displays,
+	CorePlugins::TestClient,
       ),
     }
   }

--- a/klh_core/src/klh.rs
+++ b/klh_core/src/klh.rs
@@ -127,7 +127,7 @@ use rstest::{fixture, rstest};
 
 use crate::klh::Klh;
   use crate::messaging::{Request, MessageType};
-  use crate::plugin::plugin_test_utility::{TestPlugin, COMMAND_ID, COMMAND_RESPONSE, QUERY_ID, QUERY_RESPONSE};
+  use crate::plugin::plugin_test_utility::{TestPlugin, COMMAND_ID, COMMAND_RESPONSE};
 
   // Option thing to set up if you need to debug
   #[fixture]
@@ -174,32 +174,4 @@ use crate::klh::Klh;
     let response_deserialized: String = response.deserialize().expect("Serialize correctly");
     assert_eq!(COMMAND_RESPONSE.to_string(), response_deserialized);
   }
-
-  #[tokio::test]
-  async fn should_send_query_request_and_get_response() {
-    let mut klh = Klh::new();
-    
-    let test_plugin = TestPlugin::new();
-
-    klh.add_plugin(Box::new(test_plugin));
-
-    let klh_client = klh.get_client();
-    tokio::spawn(async move {
-      klh.start().await;
-    }).await.unwrap();
-
-    let mut request = Request::from_message_type(
-      MessageType::query_from_str(QUERY_ID).unwrap()
-    );
-    let mut handler = request.get_handler().unwrap();
-
-    klh_client.send(request).await.unwrap();
-
-    let mut response = handler.handle_response().await.unwrap();
-
-    let response_deserialized: String = response.deserialize().expect("Serialize correctly");
-    assert_eq!(QUERY_RESPONSE.to_string(), response_deserialized);
-  }
-
-  
 }

--- a/klh_core/src/klh.rs
+++ b/klh_core/src/klh.rs
@@ -4,6 +4,7 @@ use crate::config::{KlhConfig, CorePlugins};
 use crate::messaging::Request;
 use crate::plugin::Plugin;
 use crate::plugins::display::Displays;
+use crate::plugins::test_client::TestClient;
 use crate::plugins::{diagnostics::Diagnostics, buffers::Buffers};
 use crate::session::{Session, SessionClient, SessionError};
 
@@ -99,13 +100,18 @@ impl Klh {
 	  debug!("Diagnostics plugin added");
 	},
 	CorePlugins::Buffers => {
-	  debug!("Adding Diagnostics plugin");
+	  debug!("Adding Buffers plugin");
 	  self.add_plugin(Box::new(Buffers::new()));
-	  debug!("Diagnostics plugin added");
+	  debug!("Buffers plugin added");
 	},
 	CorePlugins::Displays => {
 	  debug!("Adding Display plugin");
 	  self.add_plugin(Box::new(Displays::new()));
+	}
+	CorePlugins::TestClient => {
+	  debug!("Adding TestClient plugin");
+	  self.add_plugin(Box::new(TestClient::new()));
+	  debug!("TestClient plugin added");
 	}
       }
     }

--- a/klh_core/src/messaging/message.rs
+++ b/klh_core/src/messaging/message.rs
@@ -2,6 +2,23 @@ use core::fmt;
 
 use super::{MessageType, Responder, MessageContent};
 
+/// The struct which plugins send along to subscribers. Different from
+/// Message in the sense that it derives Clone and can be sent to
+/// multiple subscribers.
+#[derive(Debug, Clone)]
+pub struct EventMessage {
+  pub message_type: MessageType,
+  pub content: Option<MessageContent>,
+}
+
+impl EventMessage {
+  /// Returns the [MessageType] associated with the EventMessage.
+  pub fn get_message_type(&self) -> MessageType {
+    self.message_type
+  }
+
+}
+
 /// The fundamental struct by which plugins accept data through the
 /// [Plugin::accept_message](crate::plugin::Plugin::accept_message)
 /// interface. The plugin contains the necessary information for a

--- a/klh_core/src/messaging/message.rs
+++ b/klh_core/src/messaging/message.rs
@@ -12,6 +12,12 @@ pub struct EventMessage {
 }
 
 impl EventMessage {
+  pub fn new(message_type: MessageType, content: Option<MessageContent>) -> Self {
+    Self {
+      message_type,
+      content,
+    }
+  }
   /// Returns the [MessageType] associated with the EventMessage.
   pub fn get_message_type(&self) -> MessageType {
     self.message_type
@@ -26,13 +32,19 @@ impl EventMessage {
 /// [MessageContent] of the message, and a [Responder] with
 /// which to send an asynchronous response.
 #[derive(Debug)]
-pub struct Message {
+pub enum Message {
+  Event(EventMessage),
+  Command(CommandMessage),
+}
+
+#[derive(Debug)]
+pub struct CommandMessage {
   message_type: MessageType,
   responder: Option<Responder>,
   content: Option<MessageContent>,
 }
 
-impl Message {
+impl CommandMessage {
 
   pub(crate) fn new(
     message_type: MessageType,
@@ -73,11 +85,25 @@ impl Message {
 
 impl fmt::Display for Message {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f,"Message {{
+    match self {
+      Message::Event(event) => {
+	write!(f,"Message {{
   message_type: {},
   content: {:?},
 }}
-", self.message_type.display_id(), self.content)
+", event.message_type.display_id(), event.content)
+	
+      },
+      Message::Command(command) => {
+	write!(f,"Message {{
+  message_type: {},
+  content: {:?},
+}}
+", command.message_type.display_id(), command.content)
+	
+	
+      },
+    }
   }
 }
 

--- a/klh_core/src/messaging/message.rs
+++ b/klh_core/src/messaging/message.rs
@@ -23,6 +23,16 @@ impl EventMessage {
     self.message_type
   }
 
+  pub fn get_content(&mut self) -> Option<MessageContent> {
+    match self.content.take() {
+      None => None,
+      Some(c) => {
+	self.content = Some(c.clone());
+	Some(c)
+      }
+    }
+  }
+
 }
 
 /// The fundamental struct by which plugins accept data through the
@@ -35,6 +45,29 @@ impl EventMessage {
 pub enum Message {
   Event(EventMessage),
   Command(CommandMessage),
+}
+
+impl Message {
+  pub fn get_message_type(&self) -> MessageType {
+    match self {
+        Message::Event(event) => event.get_message_type(),
+        Message::Command(command) => command.get_message_type(),
+    }
+  }
+  pub fn get_content(&mut self) -> Option<MessageContent> {
+    match self {
+        Message::Event(event) => event.get_content(),
+        Message::Command(command) => command.get_content(),
+    }
+  }
+
+  // Probably need a better way to do this. And the signature... ugh
+  pub fn get_responder(&mut self) -> Result<Option<Responder>, String> {
+    match self {
+      Message::Event(_) => Err("event types do not have responders".to_string()),
+      Message::Command(command) => Ok(command.get_responder()),
+    }
+  }
 }
 
 #[derive(Debug)]
@@ -100,8 +133,6 @@ impl fmt::Display for Message {
   content: {:?},
 }}
 ", command.message_type.display_id(), command.content)
-	
-	
       },
     }
   }
@@ -112,6 +143,8 @@ mod message_tests {
   use rstest::*;
 
   use crate::messaging::{MessageType, MessageContent, Request};
+
+use super::Message;
 
   #[rstest]
   fn should_get_expected_content_from_message() {
@@ -154,11 +187,15 @@ mod message_tests {
       MessageContent::from_content("content"),
     );
 
-    let mut message = given_request.as_message();
+    if let Message::Command(mut command) = given_request.as_message() {
+      let responder = command.get_responder();
 
-    let responder = message.get_responder();
+      assert!(responder.is_some())
+      
+    } else {
+      panic!("should have a command from request")
+    }
 
-    assert!(responder.is_some())
   }
 
   #[rstest]
@@ -168,26 +205,30 @@ mod message_tests {
       MessageContent::from_content("content"),
     );
 
-    let mut message = given_request.as_message();
+    if let Message::Command(mut message) = given_request.as_message() {
+      let _responder_thrown_away = message.get_responder();
 
-    let _responder_thrown_away = message.get_responder();
+      let second_responder = message.get_responder();
 
-    let second_responder = message.get_responder();
+      assert!(second_responder.is_none())
+      
+    } else {
+      panic!("Should have a command message")
+    }
 
-    assert!(second_responder.is_none())
   }
 
   #[rstest]
   fn should_return_expected_message_type() {
     let mut given_request = Request::from_message_type(
-      MessageType::query_from_str("query").unwrap(),
+      MessageType::command_from_str("command").unwrap(),
     );
 
     let message = given_request.as_message();
 
     assert_eq!(
       message.get_message_type(),
-      MessageType::query_from_str("query").unwrap(),
+      MessageType::command_from_str("command").unwrap(),
     )
   }
 }

--- a/klh_core/src/messaging/message.rs
+++ b/klh_core/src/messaging/message.rs
@@ -1,38 +1,37 @@
 use core::fmt;
 
-use super::{MessageType, Responder, MessageContent};
+use super::{MessageContent, MessageType, Responder};
 
 /// The struct which plugins send along to subscribers. Different from
 /// Message in the sense that it derives Clone and can be sent to
 /// multiple subscribers.
 #[derive(Debug, Clone)]
 pub struct EventMessage {
-  pub message_type: MessageType,
-  pub content: Option<MessageContent>,
+    pub message_type: MessageType,
+    pub content: Option<MessageContent>,
 }
 
 impl EventMessage {
-  pub fn new(message_type: MessageType, content: Option<MessageContent>) -> Self {
-    Self {
-      message_type,
-      content,
+    pub fn new(message_type: MessageType, content: Option<MessageContent>) -> Self {
+        Self {
+            message_type,
+            content,
+        }
     }
-  }
-  /// Returns the [MessageType] associated with the EventMessage.
-  pub fn get_message_type(&self) -> MessageType {
-    self.message_type
-  }
-
-  pub fn get_content(&mut self) -> Option<MessageContent> {
-    match self.content.take() {
-      None => None,
-      Some(c) => {
-	self.content = Some(c.clone());
-	Some(c)
-      }
+    /// Returns the [MessageType] associated with the EventMessage.
+    pub fn get_message_type(&self) -> MessageType {
+        self.message_type
     }
-  }
 
+    pub fn get_content(&mut self) -> Option<MessageContent> {
+        match self.content.take() {
+            None => None,
+            Some(c) => {
+                self.content = Some(c.clone());
+                Some(c)
+            }
+        }
+    }
 }
 
 /// The fundamental struct by which plugins accept data through the
@@ -44,192 +43,223 @@ impl EventMessage {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum Message {
-  Event(EventMessage),
-  Command(CommandMessage),
+    Event(EventMessage),
+    Command(CommandMessage),
 }
 
 impl Message {
-  pub fn get_message_type(&self) -> MessageType {
-    match self {
-        Message::Event(event) => event.get_message_type(),
-        Message::Command(command) => command.get_message_type(),
+    pub fn get_message_type(&self) -> MessageType {
+        match self {
+            Message::Event(event) => event.get_message_type(),
+            Message::Command(command) => command.get_message_type(),
+        }
     }
-  }
-  pub fn get_content(&mut self) -> Option<MessageContent> {
-    match self {
-        Message::Event(event) => event.get_content(),
-        Message::Command(command) => command.get_content(),
+    pub fn get_content(&mut self) -> Option<MessageContent> {
+        match self {
+            Message::Event(event) => event.get_content(),
+            Message::Command(command) => command.get_content(),
+        }
     }
-  }
 
-  // Probably need a better way to do this. And the signature... ugh
-  pub fn get_responder(&mut self) -> Result<Option<Responder>, String> {
-    match self {
-      Message::Event(_) => Err("event types do not have responders".to_string()),
-      Message::Command(command) => Ok(command.get_responder()),
+    // Probably need a better way to do this. And the signature... ugh
+    pub fn get_responder(&mut self) -> Result<Option<Responder>, String> {
+        match self {
+            Message::Event(_) => Err("event types do not have responders".to_string()),
+            Message::Command(command) => Ok(command.get_responder()),
+        }
     }
-  }
 }
 
 #[derive(Debug)]
 pub struct CommandMessage {
-  message_type: MessageType,
-  responder: Option<Responder>,
-  content: Option<MessageContent>,
-}
-
-impl CommandMessage {
-
-  pub(crate) fn new(
     message_type: MessageType,
     responder: Option<Responder>,
     content: Option<MessageContent>,
-  ) -> Self {
-    Self {
-      message_type,
-      responder,
-      content,
+}
+
+impl CommandMessage {
+    pub(crate) fn new(
+        message_type: MessageType,
+        responder: Option<Responder>,
+        content: Option<MessageContent>,
+    ) -> Self {
+        Self {
+            message_type,
+            responder,
+            content,
+        }
     }
-  }
 
-  /// Returns the [MessageType] associated with the Message.
-  pub fn get_message_type(&self) -> MessageType {
-    self.message_type
-  }
-
-  /// Gets a one-time use responder with which to asynchronously
-  /// respond to the message. A `Message` instance returns [None] if
-  /// this function is called more than once.
-  pub fn get_responder(&mut self) -> Option<Responder> {
-    self.responder.take()
-  }
-
-  /// Gets the [MessageContent] of the message, if present. Otherwise,
-  /// returns [None].
-  pub fn get_content(&mut self) -> Option<MessageContent> {
-    match self.content.take() {
-      None => None,
-      Some(c) => {
-	self.content = Some(c.clone());
-	Some(c)
-      }
+    /// Returns the [MessageType] associated with the Message.
+    pub fn get_message_type(&self) -> MessageType {
+        self.message_type
     }
-  }
+
+    /// Gets a one-time use responder with which to asynchronously
+    /// respond to the message. A `Message` instance returns [None] if
+    /// this function is called more than once.
+    pub fn get_responder(&mut self) -> Option<Responder> {
+        self.responder.take()
+    }
+
+    /// Gets the [MessageContent] of the message, if present. Otherwise,
+    /// returns [None].
+    pub fn get_content(&mut self) -> Option<MessageContent> {
+        match self.content.take() {
+            None => None,
+            Some(c) => {
+                self.content = Some(c.clone());
+                Some(c)
+            }
+        }
+    }
+}
+
+impl fmt::Display for CommandMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Command Message {{
+                message_type: {},
+                content: {:?}
+            }}",
+            self.get_message_type(),
+            self.content.clone(),
+        )
+    }
+}
+
+impl fmt::Display for EventMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Event Message {{
+                message_type: {},
+                content: {:?}
+            }}",
+            self.get_message_type(),
+            self.content.clone(),
+        )
+    }
 }
 
 impl fmt::Display for Message {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    match self {
-      Message::Event(event) => {
-	write!(f,"Message {{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Message::Event(event) => {
+                write!(
+                    f,
+                    "Message {{
+                        message_type: {},
+                        event: {},
+                    }}
+",
+                    event.message_type.display_id(),
+                    event
+                )
+            }
+            Message::Command(command) => {
+                write!(
+                    f,
+                    "Message {{
   message_type: {},
-  content: {:?},
+  command: {},
 }}
-", event.message_type.display_id(), event.content)
-	
-      },
-      Message::Command(command) => {
-	write!(f,"Message {{
-  message_type: {},
-  content: {:?},
-}}
-", command.message_type.display_id(), command.content)
-      },
+",
+                    command.message_type.display_id(),
+                    command
+                )
+            }
+        }
     }
-  }
 }
 
 #[cfg(test)]
 mod message_tests {
-  use rstest::*;
+    use rstest::*;
 
-  use crate::messaging::{MessageType, MessageContent, Request};
+    use crate::messaging::{MessageContent, MessageType, Request};
 
-use super::Message;
+    use super::Message;
 
-  #[rstest]
-  fn should_get_expected_content_from_message() {
-    let mut given_request = Request::new(
-      MessageType::command_from_str("command").unwrap(),
-      MessageContent::from_content("content"),
-    );
+    #[rstest]
+    fn should_get_expected_content_from_message() {
+        let mut given_request = Request::new(
+            MessageType::command_from_str("command").unwrap(),
+            MessageContent::from_content("content"),
+        );
 
-    let mut message = given_request.as_message();
+        let mut message = given_request.as_message();
 
-    assert_eq!(
-      message.get_content(),
-      Some(MessageContent::from_content("content")),
-    )
-  }
-
-  #[rstest]
-  fn should_preserve_message_content_after_providing() {
-    let mut given_request = Request::new(
-      MessageType::command_from_str("command").unwrap(),
-      MessageContent::from_content("content"),
-    );
-
-    let mut message = given_request.as_message();
-
-    let _content_throwaway = message.get_content();
-
-    let preserved_content = message.get_content();
-
-    assert_eq!(
-      preserved_content,
-      Some(MessageContent::from_content("content")),
-    )
-  }
-
-  #[rstest]
-  fn should_provide_responder() {
-    let mut given_request = Request::new(
-      MessageType::command_from_str("command").unwrap(),
-      MessageContent::from_content("content"),
-    );
-
-    if let Message::Command(mut command) = given_request.as_message() {
-      let responder = command.get_responder();
-
-      assert!(responder.is_some())
-      
-    } else {
-      panic!("should have a command from request")
+        assert_eq!(
+            message.get_content(),
+            Some(MessageContent::from_content("content")),
+        )
     }
 
-  }
+    #[rstest]
+    fn should_preserve_message_content_after_providing() {
+        let mut given_request = Request::new(
+            MessageType::command_from_str("command").unwrap(),
+            MessageContent::from_content("content"),
+        );
 
-  #[rstest]
-  fn should_provide_none_if_asked_for_responder_twice() {
-    let mut given_request = Request::new(
-      MessageType::command_from_str("command").unwrap(),
-      MessageContent::from_content("content"),
-    );
+        let mut message = given_request.as_message();
 
-    if let Message::Command(mut message) = given_request.as_message() {
-      let _responder_thrown_away = message.get_responder();
+        let _content_throwaway = message.get_content();
 
-      let second_responder = message.get_responder();
+        let preserved_content = message.get_content();
 
-      assert!(second_responder.is_none())
-      
-    } else {
-      panic!("Should have a command message")
+        assert_eq!(
+            preserved_content,
+            Some(MessageContent::from_content("content")),
+        )
     }
 
-  }
+    #[rstest]
+    fn should_provide_responder() {
+        let mut given_request = Request::new(
+            MessageType::command_from_str("command").unwrap(),
+            MessageContent::from_content("content"),
+        );
 
-  #[rstest]
-  fn should_return_expected_message_type() {
-    let mut given_request = Request::from_message_type(
-      MessageType::command_from_str("command").unwrap(),
-    );
+        if let Message::Command(mut command) = given_request.as_message() {
+            let responder = command.get_responder();
 
-    let message = given_request.as_message();
+            assert!(responder.is_some())
+        } else {
+            panic!("should have a command from request")
+        }
+    }
 
-    assert_eq!(
-      message.get_message_type(),
-      MessageType::command_from_str("command").unwrap(),
-    )
-  }
+    #[rstest]
+    fn should_provide_none_if_asked_for_responder_twice() {
+        let mut given_request = Request::new(
+            MessageType::command_from_str("command").unwrap(),
+            MessageContent::from_content("content"),
+        );
+
+        if let Message::Command(mut message) = given_request.as_message() {
+            let _responder_thrown_away = message.get_responder();
+
+            let second_responder = message.get_responder();
+
+            assert!(second_responder.is_none())
+        } else {
+            panic!("Should have a command message")
+        }
+    }
+
+    #[rstest]
+    fn should_return_expected_message_type() {
+        let mut given_request =
+            Request::from_message_type(MessageType::command_from_str("command").unwrap());
+
+        let message = given_request.as_message();
+
+        assert_eq!(
+            message.get_message_type(),
+            MessageType::command_from_str("command").unwrap(),
+        )
+    }
 }

--- a/klh_core/src/messaging/message.rs
+++ b/klh_core/src/messaging/message.rs
@@ -41,6 +41,7 @@ impl EventMessage {
 /// plugin to get the [MessageType] of the originating request, the
 /// [MessageContent] of the message, and a [Responder] with
 /// which to send an asynchronous response.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum Message {
   Event(EventMessage),

--- a/klh_core/src/messaging/message_content.rs
+++ b/klh_core/src/messaging/message_content.rs
@@ -1,6 +1,5 @@
 use bson::{Bson, Deserializer};
-use serde::{Serialize, Deserialize};
-
+use serde::{Deserialize, Serialize};
 
 /// A serialized representation of structured content passed through
 /// Request & Response messages. This struct relies on the
@@ -9,74 +8,74 @@ use serde::{Serialize, Deserialize};
 /// types.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MessageContent {
-  content: Option<Bson>,
+    content: Option<Bson>,
 }
 
 impl MessageContent {
-  /// Creates an empty [MessageContent] struct instance.
-  pub fn empty() -> Self {
-    Self {
-      content: None,
+    /// Creates an empty [MessageContent] struct instance.
+    pub fn empty() -> Self {
+        Self { content: None }
     }
-  }
 
-  /// Creates a [MessageContent] instance which serializes the given type.
-  /// # Examples
-  /// ```
-  /// use klh_core::messaging::MessageContent;
-  /// let original_content = "This is some content".to_string();
-  /// let msg_content: MessageContent = MessageContent::from_content(original_content);
-  /// ```
-  pub fn from_content<T: Serialize>(content: T) -> Self {
-    Self {
-      content: Some(bson::to_bson(&content).unwrap()),
+    /// Creates a [MessageContent] instance which serializes the given type.
+    /// # Examples
+    /// ```
+    /// use klh_core::messaging::MessageContent;
+    /// let original_content = "This is some content".to_string();
+    /// let msg_content: MessageContent = MessageContent::from_content(original_content);
+    /// ```
+    pub fn from_content<T: Serialize>(content: T) -> Self {
+        Self {
+            content: Some(bson::to_bson(&content).unwrap()),
+        }
     }
-  }
 
-  /// One-time use function which returns an instance of type `T` if
-  /// successful.  Returns [None] if serialization
-  /// is not possible for the following reasons:
-  /// - The content was already deserialized
-  /// - The serialized content does not fit the provided type to
-  ///   deserialize.
-  /// # Examples
-  /// ```
-  /// use klh_core::messaging::MessageContent;
-  /// let mut msg_content = MessageContent::from_content("This is content".to_string());
-  /// let content: String = msg_content.deserialize().expect("Should be a string content");
-  /// assert_eq!(content, "This is content".to_string());
-  /// ```
-  pub fn deserialize<'a, T: Deserialize<'a>>(&mut self) -> Option<T> {
-    match self.content.take() {
-      None => None,
-      Some(c) => {
-	let de = Deserializer::new(c);
-	match Deserialize::deserialize(de) {
-	  // Return None if the type doesn't match
-	  Err(_) => None,
-	  Ok(content) => Some(content)
-	}
-      }
+    /// One-time use function which returns an instance of type `T` if
+    /// successful.  Returns [None] if serialization
+    /// is not possible for the following reasons:
+    /// - The content was already deserialized
+    /// - The serialized content does not fit the provided type to
+    ///   deserialize.
+    /// # Examples
+    /// ```
+    /// use klh_core::messaging::MessageContent;
+    /// let mut msg_content = MessageContent::from_content("This is content".to_string());
+    /// let content: String = msg_content.deserialize().expect("Should be a string content");
+    /// assert_eq!(content, "This is content".to_string());
+    /// ```
+    pub fn deserialize<'a, T: Deserialize<'a>>(&mut self) -> Option<T> {
+        match self.content.take() {
+            None => None,
+            Some(c) => {
+                let de = Deserializer::new(c);
+                match Deserialize::deserialize(de) {
+                    // Return None if the type doesn't match
+                    Err(_) => None,
+                    Ok(content) => Some(content),
+                }
+            }
+        }
     }
-  }
 }
 
 #[cfg(test)]
 mod message_content_tests {
-  use rstest::*;
-  use crate::messaging::MessageContent;
+    use crate::messaging::MessageContent;
+    use rstest::*;
 
-  #[rstest]
-  fn should_deserialize_expected_type() {
-    let mut msg_content = MessageContent::from_content("This is content".to_string());
-    let content: String = msg_content.deserialize().expect("Should be a string content");
-    assert_eq!(content, "This is content".to_string());
-  }
+    #[rstest]
+    fn should_deserialize_expected_type() {
+        let mut msg_content = MessageContent::from_content("This is content".to_string());
+        let content: String = msg_content
+            .deserialize()
+            .expect("Should be a string content");
+        assert_eq!(content, "This is content".to_string());
+    }
 
-  #[rstest]
-  fn should_return_none_when_deserializing_wrong_type() {
-    let mut msg_content = MessageContent::from_content("This is content".to_string());
-    let content: Option<i64> = msg_content.deserialize();
-    assert_eq!(content, None);
-  }
+    #[rstest]
+    fn should_return_none_when_deserializing_wrong_type() {
+        let mut msg_content = MessageContent::from_content("This is content".to_string());
+        let content: Option<i64> = msg_content.deserialize();
+        assert_eq!(content, None);
+    }
 }

--- a/klh_core/src/messaging/message_type.rs
+++ b/klh_core/src/messaging/message_type.rs
@@ -25,12 +25,6 @@ pub enum MessageType {
   /// [Message](super::Message) instances with a MessageType of
   /// Command to respond to the message.
   Command([u8; MESSAGE_TYPE_ID_MAX_LENGTH]),
-  /// Intended to represent requests for data from a specific
-  /// plugin. "buffers:list_buffers" is a query. Conventionally, it is
-  /// expected that [Message](super::Message) instances with a
-  /// MessageType of Query will respond via the
-  /// [Responder](super::Responder) of a message.
-  Query([u8; MESSAGE_TYPE_ID_MAX_LENGTH]),
   /// Intended to reflect a certain change has occurred at the plugin
   /// level. These message types are meant for plugins to emit to
   /// clients, rather than for clients to send to plugins. Clients
@@ -42,7 +36,7 @@ pub enum MessageType {
 /// # Examples:
 /// ```
 /// use klh_core::messaging::MessageType;
-/// let message: MessageType = MessageType::query_from_str("test").unwrap();
+/// let message: MessageType = MessageType::command_from_str("test").unwrap();
 /// assert_eq!("test".to_string(), message.display_id())
 /// ```
 impl MessageType {
@@ -55,39 +49,12 @@ impl MessageType {
 	.unwrap()
 	.replace('\u{0}', "")
 	.to_string(),
-      MessageType::Query(bytes) => std::str::from_utf8(bytes)
-	.unwrap()
-	.replace('\u{0}', "")
-	.to_string(),
       MessageType::Event(bytes) => std::str::from_utf8(bytes)
 	.unwrap()
 	.replace('\u{0}', "")
 	.to_string(),
     }
   }
-
-  /// A utility function to create a [MessageType::Query] from a &str
-  /// input. The slice will be read as bytes and serialized into an ID
-  /// of a fixed length in order to prevent dynamic sizing of
-  /// MessageType objects.
-  pub fn query_from_str(str_id: &str) -> Result<Self, MessageTypeError> {
-    if str_id.len() > MESSAGE_TYPE_ID_MAX_LENGTH {
-      Err(MessageTypeError::MessageTypeIdTooLong)
-    }
-    else {
-      let mut id: [u8; MESSAGE_TYPE_ID_MAX_LENGTH] = [0u8; MESSAGE_TYPE_ID_MAX_LENGTH];
-      for (index, b) in str_id
-	.as_bytes()
-	.iter()
-	.enumerate()
-      {
-	id[index] = *b;
-      }
-
-      Ok(Self::Query(id))
-    }
-  }
-
 
   /// A utility function to create a [MessageType::Command] from a
   /// &str input. The slice will be read as bytes and serialzied into
@@ -144,9 +111,6 @@ impl MessageType {
       Self::Command(id) => {
 	&id[0..id_check.len()] == id_check.as_bytes()
       },
-      Self::Query(id) => {
-	&id[0..id_check.len()] == id_check.as_bytes()
-      },
       Self::Event(id) => {
 	&id[0..id_check.len()] == id_check.as_bytes()
       },
@@ -180,28 +144,9 @@ mod message_type_tests {
   }
 
   #[rstest]
-  fn should_create_query_from_str() {
-    let message_type = MessageType::query_from_str("query_id").unwrap();
-
-    assert!(matches!(message_type, MessageType::Query(..)));
-    assert_eq!(message_type.display_id(), "query_id".to_string());
-  }
-
-  #[rstest]
   fn should_fail_to_create_command_from_str_too_long() {
     let command_id_too_long: String = ['a'; MESSAGE_TYPE_ID_MAX_LENGTH+1].iter().collect();
     let message_type_result = MessageType::command_from_str(&command_id_too_long);
-    assert!(message_type_result.is_err());
-    assert_eq!(
-      message_type_result.expect_err("Is an error"),
-      MessageTypeError::MessageTypeIdTooLong,
-    )
-  }
-  
-  #[rstest]
-  fn should_fail_to_create_query_from_str_too_long() {
-    let query_id_too_long: String = ['a'; MESSAGE_TYPE_ID_MAX_LENGTH+1].iter().collect();
-    let message_type_result = MessageType::query_from_str(&query_id_too_long);
     assert!(message_type_result.is_err());
     assert_eq!(
       message_type_result.expect_err("Is an error"),

--- a/klh_core/src/messaging/message_type.rs
+++ b/klh_core/src/messaging/message_type.rs
@@ -31,6 +31,12 @@ pub enum MessageType {
   /// MessageType of Query will respond via the
   /// [Responder](super::Responder) of a message.
   Query([u8; MESSAGE_TYPE_ID_MAX_LENGTH]),
+  /// Intended to reflect a certain change has occurred at the plugin
+  /// level. These message types are meant for plugins to emit to
+  /// clients, rather than for clients to send to plugins. Clients
+  /// should be able to act on these message types using
+  /// [subscribe](crate::KlhClient::subscribe)
+  Event([u8; MESSAGE_TYPE_ID_MAX_LENGTH]),
 }
 
 /// # Examples:
@@ -50,6 +56,10 @@ impl MessageType {
 	.replace('\u{0}', "")
 	.to_string(),
       MessageType::Query(bytes) => std::str::from_utf8(bytes)
+	.unwrap()
+	.replace('\u{0}', "")
+	.to_string(),
+      MessageType::Event(bytes) => std::str::from_utf8(bytes)
 	.unwrap()
 	.replace('\u{0}', "")
 	.to_string(),
@@ -101,6 +111,24 @@ impl MessageType {
     }
   }
 
+  // TODO annotate
+  pub fn event_from_str(str_id: &str) -> Result<Self, MessageTypeError> {
+    if str_id.len() > MESSAGE_TYPE_ID_MAX_LENGTH {
+      Err(MessageTypeError::MessageTypeIdTooLong)
+    }
+    else {
+      let mut id: [u8; MESSAGE_TYPE_ID_MAX_LENGTH] = [0u8; MESSAGE_TYPE_ID_MAX_LENGTH];
+      for (index, b) in str_id
+	.as_bytes()
+	.iter()
+	.enumerate()
+      {
+	id[index] = *b;
+      }
+
+      Ok(Self::Event(id))
+    }
+  }
   
   /// An instance utility function that allows you to ensure the ID of
   /// the message type matches.
@@ -118,7 +146,10 @@ impl MessageType {
       },
       Self::Query(id) => {
 	&id[0..id_check.len()] == id_check.as_bytes()
-      }
+      },
+      Self::Event(id) => {
+	&id[0..id_check.len()] == id_check.as_bytes()
+      },
     }
   }
 }

--- a/klh_core/src/messaging/request.rs
+++ b/klh_core/src/messaging/request.rs
@@ -1,6 +1,9 @@
 use tokio::sync::oneshot;
 
-use super::{CommandMessage, EventMessage, Message, MessageContent, MessageError, MessageType, Responder, ResponseHandler};
+use super::{
+    CommandMessage, EventMessage, Message, MessageContent, MessageError, MessageType, Responder,
+    ResponseHandler,
+};
 
 /// The fundamental struct with which to communicate through klh. A
 /// `Request` can apply to any [MessageType]. A user interfaces with
@@ -11,12 +14,12 @@ use super::{CommandMessage, EventMessage, Message, MessageContent, MessageError,
 /// ```no_build,no_run
 /// use klh_core::messaging::{Request, MessageType, MessageContent, MessageError};
 /// use klh_core::klh::Klh;
-/// 
+///
 /// let mut request = Request::new(
 ///   MessageType::command_from_str("plugin_name::command_name"),
 ///   MessageContent::from_content("Content"),
 /// );
-/// 
+///
 /// let klh_client = Klh::new().get_client();
 ///
 /// let mut handler = request.get_handler();
@@ -26,168 +29,162 @@ use super::{CommandMessage, EventMessage, Message, MessageContent, MessageError,
 /// let response: Result<MessageContent, MessageError> = handler.handle_response().await;
 /// ```
 pub struct Request {
-  message_type: MessageType,
-  sender: Option<Responder>,
-  receiver: Option<ResponseHandler>,
-  content: Option<MessageContent>,
+    message_type: MessageType,
+    sender: Option<Responder>,
+    receiver: Option<ResponseHandler>,
+    content: Option<MessageContent>,
 }
 
 impl Request {
-  /// Creates a request with a given [MessageType] and [MessageContent].
-  pub fn new(message_type: MessageType, content: MessageContent) -> Self {
-    let (tx, rx) = oneshot::channel();
-    Self {
-      message_type,
-      sender: Some(Responder::new(Some(tx))),
-      receiver: Some(ResponseHandler::new(Some(rx))),
-      content: Some(content),
+    /// Creates a request with a given [MessageType] and [MessageContent].
+    pub fn new(message_type: MessageType, content: MessageContent) -> Self {
+        match message_type {
+            MessageType::Command(_) => {
+                let (tx, rx) = oneshot::channel();
+                Self {
+                    message_type,
+                    sender: Some(Responder::new(Some(tx))),
+                    receiver: Some(ResponseHandler::new(Some(rx))),
+                    content: Some(content),
+                }
+            }
+            MessageType::Event(_) => Self {
+                message_type,
+                sender: None,
+                receiver: None,
+                content: Some(content),
+            },
+        }
     }
-  }
 
-  /// Creates a request with a given [MessageType]. The request will
-  /// hold no [MessageContent] data. This is useful for creating
-  /// requests for whom the MessageType communicates all the relevant
-  /// information (e.g. certain global events, such as
-  /// `ShutDownRequested`).
-  pub fn from_message_type(message_type: MessageType) -> Self {
-    let (tx, rx) = oneshot::channel();
-    Self {
-      message_type,
-      sender: Some(Responder::new(Some(tx))),
-      receiver: Some(ResponseHandler::new(Some(rx))),
-      content: None,
+    /// Creates a request with a given [MessageType]. The request will
+    /// hold no [MessageContent] data. This is useful for creating
+    /// requests for whom the MessageType communicates all the relevant
+    /// information (e.g. certain global events, such as
+    /// `ShutDownRequested`).
+    pub fn from_message_type(message_type: MessageType) -> Self {
+        let (tx, rx) = oneshot::channel();
+        Self {
+            message_type,
+            sender: Some(Responder::new(Some(tx))),
+            receiver: Some(ResponseHandler::new(Some(rx))),
+            content: None,
+        }
     }
-  }
 
-  pub(crate) fn as_message(&mut self) -> Message {
-    match self.content.take() {
-      None => Message::Command(CommandMessage::new(
-	self.message_type,
-	self.sender.take(),
-	None,
-      )),
-      Some(content) => Message::Command(CommandMessage::new(
-	self.message_type,
-	self.sender.take(),
-	Some(content),
-      )),
+    pub(crate) fn as_message(&mut self) -> Message {
+        match self.message_type {
+            MessageType::Command(_) => Message::Command(CommandMessage::new(
+                self.message_type,
+                self.sender.take(),
+                self.content.take(),
+            )),
+            MessageType::Event(_) => {
+                Message::Event(EventMessage::new(self.message_type, self.content.take()))
+            }
+        }
     }
-    
-  }
 
-  /// A one-time-use method that will return the [ResponseHandler] for
-  /// this request.
-  /// # Errors
-  /// Will return an error if the handler has already been taken from
-  /// the request.
-  pub fn get_handler(&mut self) -> Result<ResponseHandler, MessageError> {
-    match self.receiver.take() {
-      None => Err(MessageError::ResponseHandlerAlreadyTaken),
-      Some(r) => Ok(r),
+    /// A one-time-use method that will return the [ResponseHandler] for
+    /// this request.
+    /// # Errors
+    /// Will return an error if the handler has already been taken from
+    /// the request.
+    pub fn get_handler(&mut self) -> Result<ResponseHandler, MessageError> {
+        match self.receiver.take() {
+            None => Err(MessageError::ResponseHandlerAlreadyTaken),
+            Some(r) => Ok(r),
+        }
     }
-    
-  }
 }
-
-pub struct Event {
-  message_type: MessageType,
-  content: Option<MessageContent>,
-}
-
-impl Event {
-  pub fn new(message_type: MessageType, content: MessageContent) -> Self {
-    Self {
-      message_type,
-      content: Some(content),
-    }
-  }
-  pub(crate) fn as_message(&mut self) -> Message {
-    match self.content.take() {
-      None => Message::Event(EventMessage::new(
-	self.message_type,
-	None,
-      )),
-      Some(content) => Message::Event(EventMessage::new(
-	self.message_type,
-	Some(content),
-      )),
-    }
-    
-  }
-}
-
 
 #[cfg(test)]
 mod request_tests {
-  use rstest::*;
+    use rstest::*;
 
-use crate::messaging::{MessageType, MessageContent, MessageError};
+    use crate::messaging::{Message, MessageContent, MessageError, MessageType};
 
-use super::Request;
+    use super::Request;
 
-  #[rstest]
-  fn should_serialize_into_message_with_no_content() {
-    let mut request: Request = Request::from_message_type(
-      MessageType::command_from_str("cmd").unwrap()
-    );
+    #[rstest]
+    fn should_serialize_into_message_with_no_content() {
+        let mut request: Request =
+            Request::from_message_type(MessageType::command_from_str("cmd").unwrap());
 
-    let mut serialized_message = request.as_message();
+        let mut serialized_message = request.as_message();
 
-    assert_eq!(
-      serialized_message.get_content(),
-      None);
-  }
+        assert_eq!(serialized_message.get_content(), None);
+    }
 
-  #[rstest]
-  fn should_serialize_into_message_with_expected_content() {
-    let mut request: Request = Request::new(
-      MessageType::command_from_str("command").unwrap(),
-      MessageContent::from_content("content"),
-    );
+    #[rstest]
+    fn should_serialize_into_message_with_expected_content() {
+        let mut request: Request = Request::new(
+            MessageType::command_from_str("command").unwrap(),
+            MessageContent::from_content("content"),
+        );
 
-    let mut serialized_message = request.as_message();
+        let mut serialized_message = request.as_message();
 
-    assert_eq!(
-      serialized_message.get_content(),
-      Some(MessageContent::from_content("content")));
-  }
+        assert_eq!(
+            serialized_message.get_content(),
+            Some(MessageContent::from_content("content"))
+        );
+    }
 
-  #[rstest]
-  fn should_serialize_into_message_with_expected_message_type() {
-    let mut request: Request = Request::from_message_type(
-      MessageType::command_from_str("command").unwrap()
-    );
+    #[rstest]
+    fn should_serialize_into_message_with_command_message_type() {
+        let mut request: Request =
+            Request::from_message_type(MessageType::command_from_str("command").unwrap());
 
-    let serialized_message = request.as_message();
+        assert!(!request.sender.is_none());
+        assert!(!request.receiver.is_none());
+        let serialized_message = request.as_message();
+        assert!(matches!(serialized_message, Message::Command(..)));
+        assert_eq!(
+            serialized_message.get_message_type(),
+            MessageType::command_from_str("command").unwrap(),
+        );
+    }
 
-    assert_eq!(
-      serialized_message.get_message_type(),
-      MessageType::command_from_str("command").unwrap(),
-    );
-  }
+    #[rstest]
+    fn should_serialize_into_message_with_event_message_type() {
+        let mut request: Request = Request::new(
+            MessageType::event_from_str("event").unwrap(),
+            MessageContent::from_content("this is content"),
+        );
 
-  #[rstest]
-  fn should_provide_handler_when_get_handler_first_called() {
-    let mut request: Request = Request::from_message_type(
-      MessageType::command_from_str("command").unwrap()
-    );
+        assert!(request.sender.is_none());
+        assert!(request.receiver.is_none());
+        let serialized_message = request.as_message();
+        assert!(matches!(serialized_message, Message::Event(..)));
+        assert_eq!(
+            serialized_message.get_message_type(),
+            MessageType::event_from_str("event").unwrap(),
+        )
+    }
 
-    let handler = request.get_handler();
+    #[rstest]
+    fn should_provide_handler_when_get_handler_first_called() {
+        let mut request: Request =
+            Request::from_message_type(MessageType::command_from_str("command").unwrap());
 
-    assert!(handler.is_ok())
-  }
+        let handler = request.get_handler();
 
-  #[rstest]
-  fn should_return_expected_err_when_get_handler_called_more_than_once() {
-    let mut request: Request = Request::from_message_type(
-      MessageType::command_from_str("command").unwrap()
-    );
+        assert!(handler.is_ok())
+    }
 
-    let _handler = request.get_handler();
+    #[rstest]
+    fn should_return_expected_err_when_get_handler_called_more_than_once() {
+        let mut request: Request =
+            Request::from_message_type(MessageType::command_from_str("command").unwrap());
 
-    let handler = request.get_handler();
+        let _handler = request.get_handler();
 
-    assert_eq!(handler.unwrap_err(), MessageError::ResponseHandlerAlreadyTaken)
-    
-  }
+        let handler = request.get_handler();
+
+        assert_eq!(
+            handler.unwrap_err(),
+            MessageError::ResponseHandlerAlreadyTaken
+        )
+    }
 }

--- a/klh_core/src/messaging/request.rs
+++ b/klh_core/src/messaging/request.rs
@@ -1,6 +1,6 @@
 use tokio::sync::oneshot;
 
-use super::{Message, MessageType, MessageContent, Responder, ResponseHandler, MessageError};
+use super::{CommandMessage, EventMessage, Message, MessageContent, MessageError, MessageType, Responder, ResponseHandler};
 
 /// The fundamental struct with which to communicate through klh. A
 /// `Request` can apply to any [MessageType]. A user interfaces with
@@ -61,16 +61,16 @@ impl Request {
 
   pub(crate) fn as_message(&mut self) -> Message {
     match self.content.take() {
-      None => Message::new(
+      None => Message::Command(CommandMessage::new(
 	self.message_type,
 	self.sender.take(),
 	None,
-      ),
-      Some(content) => Message::new(
+      )),
+      Some(content) => Message::Command(CommandMessage::new(
 	self.message_type,
 	self.sender.take(),
 	Some(content),
-      ),
+      )),
     }
     
   }
@@ -84,6 +84,33 @@ impl Request {
     match self.receiver.take() {
       None => Err(MessageError::ResponseHandlerAlreadyTaken),
       Some(r) => Ok(r),
+    }
+    
+  }
+}
+
+pub struct Event {
+  message_type: MessageType,
+  content: Option<MessageContent>,
+}
+
+impl Event {
+  pub fn new(message_type: MessageType, content: MessageContent) -> Self {
+    Self {
+      message_type,
+      content: Some(content),
+    }
+  }
+  pub(crate) fn as_message(&mut self) -> Message {
+    match self.content.take() {
+      None => Message::Event(EventMessage::new(
+	self.message_type,
+	None,
+      )),
+      Some(content) => Message::Event(EventMessage::new(
+	self.message_type,
+	Some(content),
+      )),
     }
     
   }

--- a/klh_core/src/messaging/request.rs
+++ b/klh_core/src/messaging/request.rs
@@ -128,7 +128,7 @@ use super::Request;
   #[rstest]
   fn should_serialize_into_message_with_no_content() {
     let mut request: Request = Request::from_message_type(
-      MessageType::query_from_str("query").unwrap()
+      MessageType::command_from_str("cmd").unwrap()
     );
 
     let mut serialized_message = request.as_message();
@@ -141,7 +141,7 @@ use super::Request;
   #[rstest]
   fn should_serialize_into_message_with_expected_content() {
     let mut request: Request = Request::new(
-      MessageType::query_from_str("query").unwrap(),
+      MessageType::command_from_str("command").unwrap(),
       MessageContent::from_content("content"),
     );
 
@@ -155,21 +155,21 @@ use super::Request;
   #[rstest]
   fn should_serialize_into_message_with_expected_message_type() {
     let mut request: Request = Request::from_message_type(
-      MessageType::query_from_str("query").unwrap()
+      MessageType::command_from_str("command").unwrap()
     );
 
     let serialized_message = request.as_message();
 
     assert_eq!(
       serialized_message.get_message_type(),
-      MessageType::query_from_str("query").unwrap(),
+      MessageType::command_from_str("command").unwrap(),
     );
   }
 
   #[rstest]
   fn should_provide_handler_when_get_handler_first_called() {
     let mut request: Request = Request::from_message_type(
-      MessageType::query_from_str("query").unwrap()
+      MessageType::command_from_str("command").unwrap()
     );
 
     let handler = request.get_handler();
@@ -180,7 +180,7 @@ use super::Request;
   #[rstest]
   fn should_return_expected_err_when_get_handler_called_more_than_once() {
     let mut request: Request = Request::from_message_type(
-      MessageType::query_from_str("query").unwrap()
+      MessageType::command_from_str("command").unwrap()
     );
 
     let _handler = request.get_handler();

--- a/klh_core/src/messaging/response.rs
+++ b/klh_core/src/messaging/response.rs
@@ -93,14 +93,16 @@ use crate::messaging::{Request, MessageType, MessageContent, MessageError};
   #[tokio::test]
   async fn responder_should_respond_with_expected_content() {
     let mut given_request = Request::from_message_type(
-      MessageType::query_from_str("test").unwrap()
+      MessageType::command_from_str("test").unwrap()
     );
 
     let mut response_handler = given_request.get_handler().unwrap();
 
     let mut given_message = given_request.as_message();
 
-    let mut responder = given_message.get_responder().expect("Should be a responder available");
+    let mut responder = given_message.get_responder()
+      .expect("Should be possible to get a responder for a comman")
+      .expect("Should have its responder unused");
 
     tokio::spawn(async move {
       responder.respond(MessageContent::from_content("responding"))
@@ -117,11 +119,13 @@ use crate::messaging::{Request, MessageType, MessageContent, MessageError};
   #[rstest]
   fn responder_should_return_expected_error_when_called_to_respond_twice() {
     let mut given_request = Request::from_message_type(
-      MessageType::query_from_str("test").unwrap()
+      MessageType::command_from_str("test").unwrap()
     );
     let mut given_message = given_request.as_message();
 
-    let mut responder = given_message.get_responder().expect("Should be a responder available");
+    let mut responder = given_message.get_responder()
+      .expect("Should be possible to get a responder for a comman")
+      .expect("Should have its responder unused");
 
     responder.respond(MessageContent::from_content("content")).unwrap();
 
@@ -136,14 +140,16 @@ use crate::messaging::{Request, MessageType, MessageContent, MessageError};
   #[tokio::test]
   async fn response_hander_should_return_expected_error_when_called_to_handle_twice() {
     let mut given_request = Request::from_message_type(
-      MessageType::query_from_str("test").unwrap()
+      MessageType::command_from_str("test").unwrap()
     );
 
     let mut response_handler = given_request.get_handler().unwrap();
 
     let mut given_message = given_request.as_message();
 
-    let mut responder = given_message.get_responder().expect("Should be a responder available");
+    let mut responder = given_message.get_responder()
+      .expect("Should be possible to get a responder for a comman")
+      .expect("Should have its responder unused");
 
     tokio::spawn(async move {
       responder.respond(MessageContent::from_content("responding"))

--- a/klh_core/src/plugin/mod.rs
+++ b/klh_core/src/plugin/mod.rs
@@ -61,6 +61,8 @@ pub mod plugin_test_utility {
 	      .unwrap();
 	  }
 	},
+	// TODO a responder shouldn't occur for an event, so need some other way to handle this here.
+	MessageType::Event(_) => ()
       };
 
       Ok(())

--- a/klh_core/src/plugin/mod.rs
+++ b/klh_core/src/plugin/mod.rs
@@ -11,10 +11,8 @@ pub(crate) use plugin_channel::PluginChannel;
 
 #[cfg(test)]
 pub mod plugin_test_utility {
-  pub const QUERY_ID: &str = "queryId";
   pub const COMMAND_ID: &str = "commandId";
   pub const COMMAND_RESPONSE: &str = "commandResponse";
-  pub const QUERY_RESPONSE: &str = "queryResponse";
 
   use crate::messaging::{Message, MessageType, MessageContent, MessageError};
   use crate::session::SessionClient;
@@ -22,7 +20,6 @@ pub mod plugin_test_utility {
   
   pub struct TestPlugin {
     command_sent: bool,
-    query_sent: bool,
   }
 
   impl Default for TestPlugin {
@@ -35,7 +32,6 @@ pub mod plugin_test_utility {
     pub fn new() -> Self {
       Self {
 	command_sent: false,
-	query_sent: false,
       }
     }
   }
@@ -43,19 +39,11 @@ pub mod plugin_test_utility {
   impl Plugin for TestPlugin {
     fn accept_message(&mut self, mut message: Message) -> Result<(), MessageError> {
       match message.get_message_type() {
-	MessageType::Query(id) => {
-	  if QUERY_ID.as_bytes() == &id[0..QUERY_ID.len()] {
-	    self.query_sent = true;
-	    message.get_responder()
-	      .expect("Should have responder")
-	      .respond(MessageContent::from_content(QUERY_RESPONSE.to_string()))
-	      .unwrap();
-	  }
-	},
 	MessageType::Command(id) => {
 	  if COMMAND_ID.as_bytes() == &id[0..COMMAND_ID.len()] {
 	    self.command_sent = true;
 	    message.get_responder()
+	      .expect("Should be a command")
 	      .expect("Should have responder")
 	      .respond(MessageContent::from_content(COMMAND_RESPONSE.to_string()))
 	      .unwrap();
@@ -71,7 +59,6 @@ pub mod plugin_test_utility {
     fn list_message_types(&self) -> Vec<MessageType> {
       vec!(
 	MessageType::command_from_str(COMMAND_ID).unwrap(),
-	MessageType::query_from_str(QUERY_ID).unwrap(),
       )
     }
 

--- a/klh_core/src/plugin/plugin_channel.rs
+++ b/klh_core/src/plugin/plugin_channel.rs
@@ -83,7 +83,7 @@ impl PluginTransmitter {
 mod plugin_channel_tests {
   use rstest::*;
 
-  use crate::plugin::plugin_test_utility::{TestPlugin, QUERY_RESPONSE, QUERY_ID};
+  use crate::plugin::plugin_test_utility::{TestPlugin, COMMAND_ID, COMMAND_RESPONSE};
   use crate::messaging::{Request, MessageType, Message, MessageContent};
 
   use super::PluginChannel;
@@ -91,7 +91,7 @@ mod plugin_channel_tests {
   #[fixture]
   fn message_to_send() -> Message {
     Request::from_message_type(
-      MessageType::query_from_str(QUERY_ID).unwrap()
+      MessageType::command_from_str(COMMAND_ID).unwrap()
     ).as_message()
   }
 
@@ -99,7 +99,7 @@ mod plugin_channel_tests {
   #[tokio::test]
   async fn should_send_message_through_plugin_channel() {
     let mut given_request = Request::from_message_type(
-      MessageType::query_from_str(QUERY_ID).unwrap()
+      MessageType::command_from_str(COMMAND_ID).unwrap()
     );
     let mut response_handler = given_request.get_handler()
       .expect("response handler should be available");
@@ -121,6 +121,6 @@ mod plugin_channel_tests {
 
     let response = response_handler.handle_response().await.unwrap();
 
-    assert_eq!(response, MessageContent::from_content(QUERY_RESPONSE))
+    assert_eq!(response, MessageContent::from_content(COMMAND_RESPONSE))
   }
 }

--- a/klh_core/src/plugin/plugin_registrar.rs
+++ b/klh_core/src/plugin/plugin_registrar.rs
@@ -38,9 +38,6 @@ impl PluginRegistrar {
         MessageType::Command(_) => {
 	  self.command_plugin_map.insert(*message_type, transmitter.clone());
 	},
-        MessageType::Query(_) => {
-	  self.command_plugin_map.insert(*message_type, transmitter.clone());
-	},
         MessageType::Event(_) => {
 	  match self.event_plugin_map.get_mut(message_type) {
 	    Some(transmitters) => {

--- a/klh_core/src/plugin/plugin_registrar.rs
+++ b/klh_core/src/plugin/plugin_registrar.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use log::{debug, warn};
 
-use crate::messaging::{Message, MessageType, MessageContent, MessageError};
+use crate::messaging::{EventMessage, Message, MessageContent, MessageError, MessageType};
 
 use super::plugin_channel::PluginTransmitter;
 
@@ -11,14 +11,17 @@ use super::plugin_channel::PluginTransmitter;
 /// during its running session. Not part of the KLH public API.
 #[derive(Clone)]
 pub(crate) struct PluginRegistrar {
-  plugin_type_map: HashMap<MessageType, PluginTransmitter>,
+  command_plugin_map: HashMap<MessageType, PluginTransmitter>,
+  event_plugin_map: HashMap<MessageType, Vec<PluginTransmitter>>,
 }
 
 impl PluginRegistrar {
 
   pub(crate) fn new() -> Self {
     PluginRegistrar {
-      plugin_type_map: HashMap::new(),
+      command_plugin_map: HashMap::new(),
+      // TODO this isn't quite right, need eventmessage instead of message (no responder, true pub sub)
+      event_plugin_map: HashMap::new(),
     }
   }
 
@@ -32,7 +35,42 @@ impl PluginRegistrar {
   ) {
     for message_type in message_types.iter() {
       debug!("Registering message type {}", message_type);
-      self.plugin_type_map.insert(*message_type, transmitter.clone());
+      match message_type {
+        MessageType::Command(_) => {
+	  self.command_plugin_map.insert(*message_type, transmitter.clone());
+	},
+        MessageType::Query(_) => {
+	  self.command_plugin_map.insert(*message_type, transmitter.clone());
+	},
+        MessageType::Event(_) => {
+	  match self.event_plugin_map.get_mut(message_type) {
+	    Some(transmitters) => {
+	      transmitters.push(transmitter.clone());
+	    },
+	    None => {
+	      let transmitters = vec!(transmitter.clone());
+	      self.event_plugin_map.insert(*message_type, transmitters);
+	    },
+	  }
+	},
+      };
+    }
+  }
+
+  /// Receives an event message and sends it to all the transmitters
+  /// subscribed.
+  pub(crate) async fn send_event_to_plugin(&self, mut message: EventMessage) {
+    debug!("Plugin registrar received event message {:?}", message);
+    match self.event_plugin_map.get(&message.get_message_type()) {
+      Some(listeners) => {
+	for _listener in listeners {
+	  // listener.send_message()
+	  debug!("TODO sending message to listener");
+	}
+      },
+      None => {
+	debug!("No listeners found for event message {:?}", message)
+      }
     }
   }
 
@@ -41,7 +79,7 @@ impl PluginRegistrar {
   /// MessageType of the sent Message.
   pub(crate) async fn send_to_plugin(&self, mut message: Message) {
     debug!("Plugin registrar received message {}", message);
-    match self.plugin_type_map.get(&message.get_message_type()) {
+    match self.command_plugin_map.get(&message.get_message_type()) {
       Some(listener) => {
 	debug!("Found listener for message {}", message);
 	match listener.send_message(message).await {

--- a/klh_core/src/plugin/plugin_registrar.rs
+++ b/klh_core/src/plugin/plugin_registrar.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use log::{debug, warn};
 
-use crate::messaging::{EventMessage, Message, MessageContent, MessageError, MessageType};
+use crate::messaging::{CommandMessage, EventMessage, Message, MessageContent, MessageError, MessageType};
 
 use super::plugin_channel::PluginTransmitter;
 
@@ -20,7 +20,6 @@ impl PluginRegistrar {
   pub(crate) fn new() -> Self {
     PluginRegistrar {
       command_plugin_map: HashMap::new(),
-      // TODO this isn't quite right, need eventmessage instead of message (no responder, true pub sub)
       event_plugin_map: HashMap::new(),
     }
   }
@@ -59,13 +58,12 @@ impl PluginRegistrar {
 
   /// Receives an event message and sends it to all the transmitters
   /// subscribed.
-  pub(crate) async fn send_event_to_plugin(&self, mut message: EventMessage) {
+  async fn send_event_to_plugin(&self, message: EventMessage) {
     debug!("Plugin registrar received event message {:?}", message);
     match self.event_plugin_map.get(&message.get_message_type()) {
       Some(listeners) => {
-	for _listener in listeners {
-	  // listener.send_message()
-	  debug!("TODO sending message to listener");
+	for listener in listeners {
+	  listener.send_message(Message::Event(message.clone())).await.unwrap();
 	}
       },
       None => {
@@ -74,15 +72,13 @@ impl PluginRegistrar {
     }
   }
 
-  /// Receives a Message and sends it to one of the PluginTransmitter
-  /// instances stored in its plugin_type_map, based on the
-  /// MessageType of the sent Message.
-  pub(crate) async fn send_to_plugin(&self, mut message: Message) {
-    debug!("Plugin registrar received message {}", message);
+  async fn send_command_to_plugin(&self, mut message: CommandMessage) {
+    // TODO impl display
+    debug!("Plugin registrar received message {:?}", message);
     match self.command_plugin_map.get(&message.get_message_type()) {
       Some(listener) => {
-	debug!("Found listener for message {}", message);
-	match listener.send_message(message).await {
+	debug!("Found listener for message {:?}", message);
+	match listener.send_message(Message::Command(message)).await {
 	  Ok(_) => (),
 	  Err(e) => {
 	    debug!("Error sending message to plugin channel listener: {}", e);
@@ -90,7 +86,7 @@ impl PluginRegistrar {
 	}
       },
       None => {
-	warn!("Could not find listener message {}", message);
+	warn!("Could not find listener message {:?}", message);
 	if let Err(message_error) = message.get_responder()
 	  .expect("Should have a responder")
 	  .respond(MessageContent::from_content(MessageError::MessageTypeNotFound)) {
@@ -99,6 +95,21 @@ impl PluginRegistrar {
 	      message_error
 	    );
 	  }
+      },
+    }
+    
+  }
+
+  /// Receives a Message and sends it to one of the PluginTransmitter
+  /// instances stored in its plugin_type_map, based on the
+  /// MessageType of the sent Message.
+  pub(crate) async fn send_to_plugin(&self, message: Message) {
+    match message {
+      Message::Event(event) => {
+	self.send_event_to_plugin(event).await;
+      },
+      Message::Command(command) => {
+	self.send_command_to_plugin(command).await;
       },
     }
   }

--- a/klh_core/src/plugins/buffers/mod.rs
+++ b/klh_core/src/plugins/buffers/mod.rs
@@ -1,7 +1,7 @@
 use log::{debug, error, warn};
 use models::GetBufferResponse;
 
-use crate::{messaging::{Message, MessageContent, MessageError, MessageType, Request }, plugin::Plugin, session::SessionClient};
+use crate::{messaging::{CommandMessage, Event, Message, MessageContent, MessageError, MessageType}, plugin::Plugin, session::SessionClient};
 
 use self::models::Buffer;
 
@@ -31,26 +31,8 @@ impl Buffers {
       buffers: Vec::new(),
     }
   }
-}
-
-impl Default for Buffers {
-  fn default() -> Self {
-    Self::new()
-  }
-}
-
-impl Plugin for Buffers {
-
-  fn list_message_types(&self) -> Vec<MessageType> {
-    self.message_types.clone()
-  }
-
-  fn receive_client(&mut self, session_client: SessionClient) {
-    self.session_client = Some(session_client)
-  }
-
-  fn accept_message(&mut self, mut message: Message) -> Result<(), MessageError> {
-    debug!("[BUFFERS] received message {}", message);
+  fn accept_command(&mut self, mut message: CommandMessage) -> Result<(), MessageError> {
+    debug!("[BUFFERS] received message {:?}", message);
     let message_type = message.get_message_type();
 
     if message_type.id_equals_str("buffers::list_buffers") {
@@ -95,7 +77,7 @@ impl Plugin for Buffers {
       buffer.content.append(append_buffer_content.content);
 
       //TODO this is meh
-      let mut request = Request::new(
+      let mut request = Event::new(
 	MessageType::event_from_str("buffers:buffer_appended").unwrap(),
 	MessageContent::from_content(buffer),
       );
@@ -126,5 +108,29 @@ impl Plugin for Buffers {
       warn!("[BUFFERS] message type id not found: {}", &message.get_message_type());
     }
     Ok(())
+  }
+}
+
+impl Default for Buffers {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl Plugin for Buffers {
+
+  fn list_message_types(&self) -> Vec<MessageType> {
+    self.message_types.clone()
+  }
+
+  fn receive_client(&mut self, session_client: SessionClient) {
+    self.session_client = Some(session_client)
+  }
+
+  fn accept_message(&mut self, message: Message) -> Result<(), MessageError> {
+    match message {
+        Message::Event(_) => todo!(),
+        Message::Command(command) => self.accept_command(command),
+    }
   }
 }

--- a/klh_core/src/plugins/buffers/mod.rs
+++ b/klh_core/src/plugins/buffers/mod.rs
@@ -20,8 +20,8 @@ impl Buffers {
   pub fn new() -> Self {
     let message_types: Vec<MessageType> = vec![
       MessageType::command_from_str("buffers::create_buffer").unwrap(),
-      MessageType::query_from_str("buffers::list_buffers").unwrap(),
-      MessageType::query_from_str("buffers::get_buffer").unwrap(),
+      MessageType::command_from_str("buffers::list_buffers").unwrap(),
+      MessageType::command_from_str("buffers::get_buffer").unwrap(),
       MessageType::command_from_str("buffers:append_string").unwrap(),
     ];
 

--- a/klh_core/src/plugins/buffers/mod.rs
+++ b/klh_core/src/plugins/buffers/mod.rs
@@ -1,7 +1,7 @@
 use log::{debug, error, warn};
 use models::GetBufferResponse;
 
-use crate::{messaging::{MessageType, Message, MessageContent, MessageError, }, plugin::Plugin, session::SessionClient};
+use crate::{messaging::{Message, MessageContent, MessageError, MessageType, Request }, plugin::Plugin, session::SessionClient};
 
 use self::models::Buffer;
 
@@ -93,6 +93,18 @@ impl Plugin for Buffers {
       };
 
       buffer.content.append(append_buffer_content.content);
+
+      //TODO this is meh
+      let mut request = Request::new(
+	MessageType::event_from_str("buffers:buffer_appended").unwrap(),
+	MessageContent::from_content(buffer),
+      );
+
+      let client_clone = self.session_client.clone().expect("Should have a client");
+
+      tokio::spawn(async move {
+	client_clone.send(request.as_message()).await.unwrap();
+      });
     }
 
     else if message_type.id_equals_str("buffers::get_buffer") {

--- a/klh_core/src/plugins/buffers/mod.rs
+++ b/klh_core/src/plugins/buffers/mod.rs
@@ -1,136 +1,158 @@
 use log::{debug, error, warn};
 use models::GetBufferResponse;
 
-use crate::{messaging::{CommandMessage, Event, Message, MessageContent, MessageError, MessageType}, plugin::Plugin, session::SessionClient};
+use crate::{
+    messaging::{CommandMessage, Message, MessageContent, MessageError, MessageType, Request},
+    plugin::Plugin,
+    session::SessionClient,
+};
 
 use self::models::Buffer;
 
-
-pub mod requests;
 pub mod models;
+pub mod requests;
 
 // TODO should this be a fully public struct? I think it should...
 pub(crate) struct Buffers {
-  message_types: Vec<MessageType>,
-  session_client: Option<SessionClient>,
-  buffers: Vec<Buffer>,
+    message_types: Vec<MessageType>,
+    session_client: Option<SessionClient>,
+    buffers: Vec<Buffer>,
 }
 
 impl Buffers {
-  pub fn new() -> Self {
-    let message_types: Vec<MessageType> = vec![
-      MessageType::command_from_str("buffers::create_buffer").unwrap(),
-      MessageType::command_from_str("buffers::list_buffers").unwrap(),
-      MessageType::command_from_str("buffers::get_buffer").unwrap(),
-      MessageType::command_from_str("buffers:append_string").unwrap(),
-    ];
+    pub fn new() -> Self {
+        let message_types: Vec<MessageType> = vec![
+            MessageType::command_from_str("buffers::create_buffer").unwrap(),
+            MessageType::command_from_str("buffers::list_buffers").unwrap(),
+            MessageType::command_from_str("buffers::get_buffer").unwrap(),
+            MessageType::command_from_str("buffers:append_string").unwrap(),
+        ];
 
-    Self {
-      message_types,
-      session_client: None,
-      buffers: Vec::new(),
+        Self {
+            message_types,
+            session_client: None,
+            buffers: Vec::new(),
+        }
     }
-  }
-  fn accept_command(&mut self, mut message: CommandMessage) -> Result<(), MessageError> {
-    debug!("[BUFFERS] received message {:?}", message);
-    let message_type = message.get_message_type();
+    fn accept_command(&mut self, mut message: CommandMessage) -> Result<(), MessageError> {
+        debug!("[BUFFERS] received message {:?}", message);
+        let message_type = message.get_message_type();
 
-    if message_type.id_equals_str("buffers::list_buffers") {
-      let response = models::ListBuffersResponse {
-	buffer_names: self.buffers.iter().map(|b| b.name.clone()).collect(),
-      };
-      if let Err(e) = message.get_responder()
-	.expect("No one should have used the responder yet")
-	.respond(MessageContent::from_content(response)) {
-	  error!("[BUFFERS] Unable to respond to message. Error: {:?}", e);
-	  return Err(MessageError::PluginFailedToProcessMessage);
-	}
+        if message_type.id_equals_str("buffers::list_buffers") {
+            let response = models::ListBuffersResponse {
+                buffer_names: self.buffers.iter().map(|b| b.name.clone()).collect(),
+            };
+            if let Err(e) = message
+                .get_responder()
+                .expect("No one should have used the responder yet")
+                .respond(MessageContent::from_content(response))
+            {
+                error!("[BUFFERS] Unable to respond to message. Error: {:?}", e);
+                return Err(MessageError::PluginFailedToProcessMessage);
+            }
+        } else if message_type.id_equals_str("buffers::create_buffer") {
+            let mut message_content = message.get_content().expect("Content should be present");
+            let create_buffer_content: models::CreateBufferRequest = message_content
+                .deserialize()
+                .expect("Should be able to deserialize");
 
+            debug!(
+                "[BUFFERS] Creating buffer with name {}",
+                &create_buffer_content.name
+            );
+
+            if self
+                .buffers
+                .iter()
+                .any(|b| b.name == create_buffer_content.name)
+            {
+                return Err(MessageError::BadRequest(String::from(
+                    "Buffer name already exists",
+                )));
+            }
+
+            self.buffers.push(Buffer::new(create_buffer_content.name));
+        } else if message_type.id_equals_str("buffers:append_string") {
+            let mut message_content = message.get_content().expect("Content should be present");
+            let append_buffer_content: models::AppendStringToBufferRequest = message_content
+                .deserialize()
+                .expect("Should be able to deserialize");
+
+            let buffer = match self
+                .buffers
+                .iter_mut()
+                .find(|b| b.name == append_buffer_content.buffer_name)
+            {
+                Some(buffer) => buffer,
+                None => {
+                    return Err(MessageError::BadRequest(String::from(
+                        "No buffer matching provided name",
+                    )))
+                }
+            };
+
+            buffer.content.append(append_buffer_content.content);
+
+            //TODO this is meh
+            let mut request = Request::new(
+                MessageType::event_from_str("buffers:buffer_appended").unwrap(),
+                MessageContent::from_content(buffer),
+            );
+
+            let client_clone = self.session_client.clone().expect("Should have a client");
+
+            tokio::spawn(async move {
+                client_clone.send(request.as_message()).await.unwrap();
+            });
+        } else if message_type.id_equals_str("buffers::get_buffer") {
+            let mut message_content = message.get_content().expect("Content should be present");
+            let get_buffer_request: models::GetBufferRequest = message_content
+                .deserialize()
+                .expect("Should be able to deserialize");
+
+            let buffer = self
+                .buffers
+                .iter()
+                .find(|b| b.name == get_buffer_request.buffer_name);
+            if let Err(e) = message
+                .get_responder()
+                .expect("No one should have used the responder yet")
+                .respond(MessageContent::from_content(GetBufferResponse {
+                    buffer: buffer.cloned(),
+                }))
+            {
+                error!("[BUFFERS] Unable to respond to message. Error: {:?}", e);
+                return Err(MessageError::PluginFailedToProcessMessage);
+            }
+        } else {
+            warn!(
+                "[BUFFERS] message type id not found: {}",
+                &message.get_message_type()
+            );
+        }
+        Ok(())
     }
-
-    else if message_type.id_equals_str("buffers::create_buffer") {
-      let mut message_content = message.get_content().expect("Content should be present");
-      let create_buffer_content : models::CreateBufferRequest = message_content
-	.deserialize()
-	.expect("Should be able to deserialize");
-
-      debug!("[BUFFERS] Creating buffer with name {}", &create_buffer_content.name);
-
-      if self.buffers.iter().any(|b| b.name == create_buffer_content.name) {
-	return Err(MessageError::BadRequest(String::from("Buffer name already exists")))
-      }
-
-      self.buffers.push(Buffer::new(create_buffer_content.name));
-    }
-
-    else if message_type.id_equals_str("buffers:append_string") {
-      let mut message_content = message.get_content().expect("Content should be present");
-      let append_buffer_content : models::AppendStringToBufferRequest = message_content
-	.deserialize()
-	.expect("Should be able to deserialize");
-
-      let buffer = match self.buffers.iter_mut().find(|b| b.name == append_buffer_content.buffer_name) {
-        Some(buffer) => buffer,
-        None => return Err(MessageError::BadRequest(String::from("No buffer matching provided name"))),
-      };
-
-      buffer.content.append(append_buffer_content.content);
-
-      //TODO this is meh
-      let mut request = Event::new(
-	MessageType::event_from_str("buffers:buffer_appended").unwrap(),
-	MessageContent::from_content(buffer),
-      );
-
-      let client_clone = self.session_client.clone().expect("Should have a client");
-
-      tokio::spawn(async move {
-	client_clone.send(request.as_message()).await.unwrap();
-      });
-    }
-
-    else if message_type.id_equals_str("buffers::get_buffer") {
-      let mut message_content = message.get_content().expect("Content should be present");
-      let get_buffer_request : models::GetBufferRequest = message_content
-	.deserialize()
-	.expect("Should be able to deserialize");
-      
-      let buffer = self.buffers.iter().find(|b| b.name == get_buffer_request.buffer_name);
-      if let Err(e) = message.get_responder()
-	.expect("No one should have used the responder yet")
-	.respond(MessageContent::from_content(GetBufferResponse { buffer: buffer.cloned() })) {
-	  error!("[BUFFERS] Unable to respond to message. Error: {:?}", e);
-	  return Err(MessageError::PluginFailedToProcessMessage);
-	}
-    }
-
-    else {
-      warn!("[BUFFERS] message type id not found: {}", &message.get_message_type());
-    }
-    Ok(())
-  }
 }
 
 impl Default for Buffers {
-  fn default() -> Self {
-    Self::new()
-  }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Plugin for Buffers {
-
-  fn list_message_types(&self) -> Vec<MessageType> {
-    self.message_types.clone()
-  }
-
-  fn receive_client(&mut self, session_client: SessionClient) {
-    self.session_client = Some(session_client)
-  }
-
-  fn accept_message(&mut self, message: Message) -> Result<(), MessageError> {
-    match message {
-        Message::Event(_) => todo!(),
-        Message::Command(command) => self.accept_command(command),
+    fn list_message_types(&self) -> Vec<MessageType> {
+        self.message_types.clone()
     }
-  }
+
+    fn receive_client(&mut self, session_client: SessionClient) {
+        self.session_client = Some(session_client)
+    }
+
+    fn accept_message(&mut self, message: Message) -> Result<(), MessageError> {
+        match message {
+            Message::Event(_) => todo!(),
+            Message::Command(command) => self.accept_command(command),
+        }
+    }
 }

--- a/klh_core/src/plugins/buffers/requests.rs
+++ b/klh_core/src/plugins/buffers/requests.rs
@@ -4,7 +4,7 @@ use super::models::{AppendStringToBufferRequest, CreateBufferRequest, GetBufferR
 
 pub fn new_list_buffers_request() -> Request {
   Request::from_message_type(
-    MessageType::query_from_str("buffers::list_buffers").unwrap()
+    MessageType::command_from_str("buffers::list_buffers").unwrap()
   )
 }
 
@@ -37,7 +37,7 @@ pub fn new_get_buffer_request(name: &str) -> Request {
   };
 
   Request::new(
-    MessageType::query_from_str("buffers::get_buffer").unwrap(),
+    MessageType::command_from_str("buffers::get_buffer").unwrap(),
     MessageContent::from_content(get_buffer_request),
   )
 }

--- a/klh_core/src/plugins/diagnostics/mod.rs
+++ b/klh_core/src/plugins/diagnostics/mod.rs
@@ -2,7 +2,7 @@ use std::{thread, time};
 
 use log::{debug, warn, info};
 
-use crate::{plugin::Plugin, messaging::{MessageType, Message, MessageContent, MessageError}, session::SessionClient};
+use crate::{messaging::{CommandMessage, Message, MessageContent, MessageError, MessageType}, plugin::Plugin, session::SessionClient};
 
 
 pub mod requests;
@@ -36,11 +36,9 @@ impl Diagnostics {
       session_client: None,
     }
   }
-}
-impl Plugin for Diagnostics {
 
-  fn accept_message(&mut self, mut message: Message) -> Result<(), MessageError> {
-    debug!("[DIAGNOSTICS] Diagnostics received message {}", message);
+  fn accept_command(&mut self, mut message: CommandMessage) -> Result<(), MessageError> {
+    debug!("[DIAGNOSTICS] Diagnostics received message {:?}", message);
     let message_type = message.get_message_type();
 
     if message_type.id_equals_str("diagnostics::log_event") {
@@ -64,6 +62,15 @@ impl Plugin for Diagnostics {
     }
     
     Ok(())
+  }
+}
+impl Plugin for Diagnostics {
+
+  fn accept_message(&mut self, message: Message) -> Result<(), MessageError> {
+    match message {
+        Message::Event(_) => todo!(),
+        Message::Command(command) => self.accept_command(command),
+    }
   }
 
   fn list_message_types(&self) -> Vec<MessageType> {

--- a/klh_core/src/plugins/display/mod.rs
+++ b/klh_core/src/plugins/display/mod.rs
@@ -1,7 +1,7 @@
 use log::{debug, warn, error};
 use models::{AcceptStringInputRequest, AttachBufferRequest, GetWindowRequest, GetWindowResponse};
 
-use crate::{messaging::{Message, MessageContent, MessageError, MessageType}, plugin::Plugin, plugins::{buffers, display::models::CreateWindowRequest}, session::SessionClient};
+use crate::{messaging::{CommandMessage, Message, MessageContent, MessageError, MessageType}, plugin::Plugin, plugins::{buffers, display::models::CreateWindowRequest}, session::SessionClient};
 
 use self::models::Window;
 
@@ -34,18 +34,9 @@ impl Displays {
       windows: Vec::new(),
     }
   }
-}
 
-impl Default for Displays {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Plugin for Displays {
-
-    fn accept_message(&mut self, mut message: Message) -> Result<(), MessageError> {
-      debug!("[DISPLAY] received message {}", message);
+  fn accept_command(&mut self, mut message: CommandMessage) -> Result<(), MessageError> {
+      debug!("[DISPLAY] received command message {:?}", message);
       let message_type = message.get_message_type();
 
       if message_type.id_equals_str("display::list_windows") {
@@ -140,6 +131,24 @@ impl Plugin for Displays {
       }
 
       Ok(())
+  }
+}
+
+impl Default for Displays {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for Displays {
+
+    fn accept_message(&mut self, message: Message) -> Result<(), MessageError> {
+      match message {
+        Message::Event(_) => todo!(),
+        Message::Command(command) => {
+	  self.accept_command(command)
+	},
+    }
     }
 
     fn list_message_types(&self) -> Vec<MessageType> {

--- a/klh_core/src/plugins/display/mod.rs
+++ b/klh_core/src/plugins/display/mod.rs
@@ -19,12 +19,12 @@ impl Displays {
   pub fn new() -> Self {
     let message_types: Vec<MessageType> = vec![
       MessageType::command_from_str("display::create_window").unwrap(),
-      MessageType::query_from_str("display::list_windows").unwrap(),
-      MessageType::query_from_str("display::get_window").unwrap(),
+      MessageType::command_from_str("display::list_windows").unwrap(),
+      MessageType::command_from_str("display::get_window").unwrap(),
       MessageType::command_from_str("display::delete_window").unwrap(),
       MessageType::command_from_str("display::attach_buffer").unwrap(),
       MessageType::command_from_str("display::detach_buffer").unwrap(),
-      MessageType::query_from_str("display::list_buffers_in_window").unwrap(),
+      MessageType::command_from_str("display::list_buffers_in_window").unwrap(),
       MessageType::command_from_str("display::accept_string_input").unwrap(),
     ];
 

--- a/klh_core/src/plugins/display/requests.rs
+++ b/klh_core/src/plugins/display/requests.rs
@@ -49,13 +49,13 @@ pub fn new_detach_buffer_request() -> Request {
 // TODO window ID argument
 pub fn new_list_buffers_in_window() -> Request {
   Request::from_message_type(
-    MessageType::query_from_str("display::list_buffers_in_window").unwrap()
+    MessageType::command_from_str("display::list_buffers_in_window").unwrap()
   )
 }
 
 pub fn new_list_windows_request() -> Request {
   Request::from_message_type(
-    MessageType::query_from_str("display::list_windows").unwrap()
+    MessageType::command_from_str("display::list_windows").unwrap()
   )
 }
 
@@ -64,7 +64,7 @@ pub fn new_get_window_request(window_name: &str) -> Request {
     window_name: window_name.to_string(),
   };
   Request::new(
-    MessageType::query_from_str("display::get_window").unwrap(),
+    MessageType::command_from_str("display::get_window").unwrap(),
     MessageContent::from_content(get_window_request),
   )
 }

--- a/klh_core/src/plugins/mod.rs
+++ b/klh_core/src/plugins/mod.rs
@@ -1,3 +1,4 @@
 pub mod buffers;
 pub mod display;
 pub mod diagnostics;
+pub mod test_client;

--- a/klh_core/src/plugins/test_client/mod.rs
+++ b/klh_core/src/plugins/test_client/mod.rs
@@ -1,0 +1,31 @@
+use log::debug;
+
+use crate::{messaging::MessageType, plugin::Plugin, session};
+
+#[derive(Default)]
+pub struct TestClient {
+  client: Option<session::SessionClient>,
+}
+
+impl TestClient {
+  pub fn new() -> Self {
+    Self {
+      client: None,
+    }
+  }
+}
+
+impl Plugin for TestClient {
+    fn accept_message(&mut self, message: crate::messaging::Message) -> Result<(), crate::messaging::MessageError> {
+      debug!("[TESTCLIENT] Received message {}", message);
+      Ok(())
+    }
+
+    fn list_message_types(&self) -> Vec<crate::messaging::MessageType> {
+        vec!(MessageType::event_from_str("buffers:buffer_appended").unwrap())
+    }
+
+    fn receive_client(&mut self, client: crate::session::SessionClient) {
+        self.client = Some(client);
+    }
+}

--- a/klh_core/src/session/session.rs
+++ b/klh_core/src/session/session.rs
@@ -130,7 +130,7 @@ mod session_tests {
   use super::Session;
   use crate::messaging::{Request, MessageType, MessageError};
   use crate::session::session::SessionError;
-  use crate::plugin::plugin_test_utility::{TestPlugin, QUERY_ID, QUERY_RESPONSE};
+  use crate::plugin::plugin_test_utility::{TestPlugin, COMMAND_ID, COMMAND_RESPONSE};
 
   #[fixture]
   fn default_session() -> Session {
@@ -146,7 +146,7 @@ mod session_tests {
     let client = default_session.get_client();
     default_session.run().await.unwrap();
     let mut request = Request::from_message_type(
-      MessageType::query_from_str(QUERY_ID).unwrap()
+      MessageType::command_from_str(COMMAND_ID).unwrap()
     );
     let mut handler = request.get_handler().unwrap();
 
@@ -156,7 +156,7 @@ mod session_tests {
 
     let deserialized_response: String = response.deserialize()
       .expect("Should deserialize into a string");
-    assert_eq!(QUERY_RESPONSE.to_string(), deserialized_response);
+    assert_eq!(COMMAND_RESPONSE.to_string(), deserialized_response);
   }
 
   #[rstest]
@@ -174,7 +174,7 @@ mod session_tests {
     let client = default_session.get_client();
 
     let mut unknown_request = Request::from_message_type(
-      MessageType::query_from_str("unknown").unwrap()
+      MessageType::command_from_str("unknown").unwrap()
     );
 
     let mut handler = unknown_request.get_handler().unwrap();

--- a/klh_test_client/src/main.rs
+++ b/klh_test_client/src/main.rs
@@ -24,7 +24,6 @@ wg: Get a window
 dl: Send a log event to diagnostics
 db: Send a slow bomb to diagnostics
 write: Send some data to a window for writing to a buffer
-bad_query: Send an unknown query through the client
 bad_command: Send an unknown command through the client
 e: exit
     ");
@@ -32,13 +31,6 @@ e: exit
     match io::stdin().read_line(&mut input) {
       Ok(_n) => {
 	match input.as_str().trim() {
-	  "bad_query" => {
-	    println!("Sending bogus query");
-	    let bad_query = Request::from_message_type(
-	      MessageType::query_from_str("NoSuchId").unwrap()
-	    );
-	    client.send(bad_query).await.unwrap();
-	  },
 	  "bad_command" => {
 	    println!("Sending bogus command");
 	    let bad_command = Request::from_message_type(

--- a/project.org
+++ b/project.org
@@ -587,3 +587,11 @@ Probably need to change Message to an interface? Hrm. Or an enum where
 one has a responder and one doesn't?
 
 This is because messagetransmitter assumes type, but event messages need to be clonable (since multiple subscribers can be listening), and that isn't feasible if they have responders
+
+** 2025-02-15
+Finally consolidated queries and commands into just commands. I think at this point I need to figure out how to have the client read events. Probably best implemented as a plugin?
+
+- Try and use slow-bombs and display updates as examples, and figure out looping logic in the test client.
+- After that, merge in and start on an Iced implementation for a front end and an actual RPC protocol - probably unix sockets?
+
+

--- a/project.org
+++ b/project.org
@@ -581,3 +581,9 @@ Tasks to make this work:
 - Create the "event" message type
 - Verify it works, e.g. with windows in the test client
 - (Maybe) collapse the query & command message types? Just turn it into "request"? As opposed to "events" to which clients subscribe.
+
+** 2024-11-26
+Probably need to change Message to an interface? Hrm. Or an enum where
+one has a responder and one doesn't?
+
+This is because messagetransmitter assumes type, but event messages need to be clonable (since multiple subscribers can be listening), and that isn't feasible if they have responders

--- a/project.org
+++ b/project.org
@@ -593,5 +593,7 @@ Finally consolidated queries and commands into just commands. I think at this po
 
 - Try and use slow-bombs and display updates as examples, and figure out looping logic in the test client.
 - After that, merge in and start on an Iced implementation for a front end and an actual RPC protocol - probably unix sockets?
+** 2025-02-22
+Sooo close to having something mergable. Get the commands/events to implement "display", then get it in. Then do a big rustfmt that is badly needed, and I guess keep using zed from here? it's sweet.
 
 


### PR DESCRIPTION
Adds the concept of events, and wires up a placeholder for the concept of a client as a plugin itself. Need to get back to `main` so that I can do a larger rustfmt and then start on the next phases:
- Build out client as a plugin
- Make events dynamically subscribable